### PR TITLE
[BC] Support multi-line test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ Shows config comments at the top of code examples:
 // Test cases
 ```
 
+#### `tabWidth` (default `4`)
+Number of spaces to convert tabs to in code examples. Tabs in examples are always converted to spaces so their widths can be determined reliably for alignment.
+
 ## ✏️ Examples
 * [Rule in eslint-plugin-no-jquery](https://github.com/wikimedia/eslint-plugin-no-jquery/blob/master/docs/no-error-shorthand.md)
 * [Rule in eslint-plugin-mediawiki](https://github.com/wikimedia/eslint-plugin-mediawiki/blob/master/docs/valid-package-file-require.md)

--- a/src/default-config.js
+++ b/src/default-config.js
@@ -6,6 +6,7 @@ module.exports = {
 	pluginName: pluginName,
 	fixCodeExamples: true,
 	showConfigComments: false,
+	tabWidth: 4,
 	templatePath: null,
 	docPath: null,
 	rulePath: null,

--- a/tests/build-docs-from-tests.js
+++ b/tests/build-docs-from-tests.js
@@ -60,6 +60,18 @@ describe( 'buildDocsFromTests', () => {
 						output: 'var y = "45678"'
 					},
 					{
+						code: 'multi\n.line\n.case',
+						output: 'Multi\n.Line.Case;'
+					},
+					{
+						code: 'multi.line.case',
+						output: 'Multi\n.Line\n.Case;'
+					},
+					{
+						code: 'singleAfterMulti;',
+						output: 'SingleAfterMulti;'
+					},
+					{
 						code: 'var z1 = "1.23"',
 						options: [ { myOption: true } ],
 						output: 'var z1 = "123"'

--- a/tests/cases/simple-rule.md
+++ b/tests/cases/simple-rule.md
@@ -15,6 +15,13 @@ My simple rule enforces a thing
 /* eslint eslint-docgen/simple-rule: "error"*/
 var x = '1.23';
 var y = '4.5678';
+
+multi
+    .line
+    .case;
+
+multi.line.case;
+singleAfterMulti;
 ```
 
 ❌ Examples of **incorrect** code with `[{"myOption":true}]` options:
@@ -55,6 +62,16 @@ var z1 = '1,23';
 /* eslint eslint-docgen/simple-rule: "error"*/
 var x = '1.23';   /* → */ var x = '123';
 var y = '4.5678'; /* → */ var y = '45678';
+
+multi             /* → */ Multi
+    .line         /* → */     .Line.Case;
+    .case;        /* → */
+
+multi.line.case;  /* → */ Multi
+                  /* → */     .Line
+                  /* → */     .Case;
+
+singleAfterMulti; /* → */ SingleAfterMulti;
 ```
 
 🔧 Examples of code **fixed** by using  `--fix` with `[{"myOption":true}]` options:


### PR DESCRIPTION
Breaking change: changes the output of multi-line test cases.

* Add newlines before and after such cases
* Add arrow comments to very line
* Replace tabs with spaces so widths can be measured

Fixes #34