### PR TITLE
[BC] Sort examples by options *then* valid/invalid

### DIFF
--- a/src/templates/examples.ejs
+++ b/src/templates/examples.ejs
@@ -1,10 +1,5 @@
-<% invalid.forEach( ( section ) => { %>
-<%- include( 'exampleInvalid', { section: section } ) %>
-<%- section.examples %>
-<% } ) %>
-
-<% valid.forEach( ( section ) => { %>
-<%- include( 'exampleValid', { section: section } ) %>
+<% validInvalid.forEach( ( section ) => { %>
+<%- include( section.valid ? 'exampleValid' : 'exampleInvalid', { section: section } ) %>
 <%- section.examples %>
 <% } ) %>
 

--- a/tests/cases/no-fix-code-examples.md
+++ b/tests/cases/no-fix-code-examples.md
@@ -2,18 +2,18 @@
 
 ## Rule details
 
-❌ Examples of **incorrect** code with `[{"myOption":true}]` options:
-```js
-/*eslint my-plugin/my-rule: ["error",[{"myOption":true}]]*/
-var x="1.23"
-var y="4.5678"
-```
-
 ✔️ Examples of **correct** code:
 ```js
 /*eslint my-plugin/my-rule: "error"*/
 var x="123"
 var y="45678"
+```
+
+❌ Examples of **incorrect** code with `[{"myOption":true}]` options:
+```js
+/*eslint my-plugin/my-rule: ["error",[{"myOption":true}]]*/
+var x="1.23"
+var y="4.5678"
 ```
 
 🔧 Examples of code **fixed** by using  `--fix` with `[{"myOption":true}]` options:

--- a/tests/cases/simple-rule.md
+++ b/tests/cases/simple-rule.md
@@ -23,17 +23,22 @@ multi.line.case;
 singleAfterMulti;
 ```
 
-❌ Examples of **incorrect** code with `[{"myOption":true}]` options:
-```js
-var z1 = '1.23';
-var z2 = '1.23';
-```
-
 ✔️ Examples of **correct** code:
 ```js
 var x = '123';
 var y = '45678';
 var z = { a: 3, ...b };
+```
+
+✔️ Examples of **correct** code with `[{"myOption":true}]` options and `[{"lang":"fr"}]` settings:
+```js
+var z1 = '1,23';
+```
+
+❌ Examples of **incorrect** code with `[{"myOption":true}]` options:
+```js
+var z1 = '1.23';
+var z2 = '1.23';
 ```
 
 ✔️ Examples of **correct** code with `[{"myOption":true}]` options:
@@ -45,11 +50,6 @@ var z2 = '123';
 ✔️ Examples of **correct** code with `[{"lang":"fr"}]` settings:
 ```js
 var x = '1,23';
-```
-
-✔️ Examples of **correct** code with `[{"myOption":true}]` options and `[{"lang":"fr"}]` settings:
-```js
-var z1 = '1,23';
 ```
 
 🔧 Examples of code **fixed** by using  `--fix`:


### PR DESCRIPTION
Breaking change: Changes the sort order for examples with options.

Fixes #48