### PR TITLE
Support scoped plugin names

### DIFF
--- a/src/default-config.js
+++ b/src/default-config.js
@@ -2,7 +2,8 @@
 
 const packagePath = require( './package-path' );
 const packageName = require( packagePath( './package' ) ).name;
-const pluginName = packageName.replace( 'eslint-plugin-', '' );
+const naming = require( './naming' );
+const pluginName = naming.getShorthandName( packageName, 'eslint-plugin' );
 
 module.exports = {
 	pluginName: pluginName,

--- a/src/naming.js
+++ b/src/naming.js
@@ -1,0 +1,36 @@
+'use strict';
+
+// istanbul ignore file
+// Method is tested upstream
+
+/**
+ * Removes the prefix from a fullname.
+ *
+ * Copied from https://github.com/eslint/eslint/blob/master/lib/shared/naming.js
+ *
+ * @param {string} fullname The term which may have the prefix.
+ * @param {string} prefix The prefix to remove.
+ * @return {string} The term without prefix.
+ */
+function getShorthandName( fullname, prefix ) {
+	if ( fullname[ 0 ] === '@' ) {
+		let matchResult = new RegExp( `^(@[^/]+)/${prefix}$`, 'u' ).exec( fullname );
+
+		if ( matchResult ) {
+			return matchResult[ 1 ];
+		}
+
+		matchResult = new RegExp( `^(@[^/]+)/${prefix}-(.+)$`, 'u' ).exec( fullname );
+		if ( matchResult ) {
+			return `${matchResult[ 1 ]}/${matchResult[ 2 ]}`;
+		}
+	} else if ( fullname.startsWith( `${prefix}-` ) ) {
+		return fullname.slice( prefix.length + 1 );
+	}
+
+	return fullname;
+}
+
+module.exports = {
+	getShorthandName: getShorthandName
+};

--- a/tests/build-docs-from-tests.js
+++ b/tests/build-docs-from-tests.js
@@ -206,7 +206,6 @@ describe( 'buildDocsFromTests', () => {
 				invalid: [
 					{
 						code: 'var x="1.23"',
-						// Rule is not fixable, so output is ignored
 						output: 'var x="123"'
 					}
 				]
@@ -228,11 +227,7 @@ describe( 'buildDocsFromTests', () => {
 					'var x="4.56"'
 				],
 				invalid: [
-					{
-						code: 'var x="1.23"',
-						// Rule is not fixable, so output is ignored
-						output: 'var x="123"'
-					}
+					'var x="1.23"'
 				]
 			},
 			config: {
@@ -240,12 +235,29 @@ describe( 'buildDocsFromTests', () => {
 			},
 			messages: [ noDesc ],
 			expected: 'cases/rule-template-path.md'
+		},
+		{
+			description: 'scoped plugin',
+			tests: {
+				valid: [
+					'var x="4.56"'
+				],
+				invalid: [
+					'var x="1.23"'
+				]
+			},
+			config: {
+				showConfigComments: true
+			},
+			messages: [ noDesc ],
+			cwd: 'cases/plugin-scoped',
+			expected: 'cases/scoped-plugin.md'
 		}
 	];
 
 	cases.forEach( ( caseItem ) => {
 		it( caseItem.description, () => {
-			testUtils.mockCwd( 'cases/plugin/src' );
+			testUtils.mockCwd( caseItem.cwd || 'cases/plugin/src' );
 
 			const buildDocsFromTests = require( '../src/build-docs-from-tests' );
 			const loadTemplates = require( '../src/load-templates' );

--- a/tests/cases/plugin-scoped/package.json
+++ b/tests/cases/plugin-scoped/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "@user/eslint-plugin-scoped",
+	"main": "main.js"
+}

--- a/tests/cases/scoped-plugin.md
+++ b/tests/cases/scoped-plugin.md
@@ -1,22 +1,18 @@
-== My rule ==
-
-Custom template for my rule.
+# my-rule
 
 ## Rule details
 
 ❌ Examples of **incorrect** code:
 ```js
-var x = '1.23';
+/* eslint @user/scoped/my-rule: "error" */
+const x = '1.23';
 ```
 
 ✔️ Examples of **correct** code:
 ```js
-var x = '4.56';
+/* eslint @user/scoped/my-rule: "error" */
+const x = '4.56';
 ```
-
-## When not to use use
-
-You may not need this rule if you don't use ES6.
 
 ## Resources
 


### PR DESCRIPTION
Use a copy of upstream's getShorthandName, which unfortunately is not published so we can't reliably just use it directly.