### PR TITLE
Add an editorconfig to make the tabs a reasonable width on GitHub

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,4 +2,4 @@ root = true
 
 [*]
 indent_style = tab
-indent_size = 2
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 2


### PR DESCRIPTION
Example:

https://github.com/j-f1/forked-eslint-docgen/blob/ae6d00212eaff3e031f4fe5f5d58d37ece79f066/src/rule-tester.js