### PR TITLE
Use DOCGEN environment variable instead of --doc flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ const RuleTester = require( 'eslint-docgen' ).RuleTester;
 Create a configuration file as described in [*Configuration*](#%EF%B8%8F-configuration), setting `docPath` and preferably `rulePath` and `testPath`.
 
 ## 📖 Usage
-To build your documentation, run your rule tests with a `--doc` flag in the command line, e.g.
+To build your documentation, run your rule tests with the `DOCGEN` environment variable set in the command line, e.g.
 ```sh
-mocha tests/rules/ --doc
+DOCGEN=1 mocha tests/rules/
 ```
 
 Documentation will be built using **rule metadata** and **test data** passed to `RuleTester`:

--- a/src/rule-tester.js
+++ b/src/rule-tester.js
@@ -3,7 +3,14 @@
 const packagePath = require( './package-path' );
 // Use plugin's version of ESLint
 const ESLintRuleTester = require( packagePath( 'node_modules/eslint' ) ).RuleTester;
-const docMode = process.argv.includes( '--doc' );
+const docMode = !!process.env.DOCGEN || process.argv.includes( '--doc' );
+
+if ( process.argv.includes( '--doc' ) ) {
+	const formatter = require( './formatter' );
+	console.log(
+		formatter.warn( '--doc is deprecated, use the DOCGEN=1 environment variable instead.' )
+	);
+}
 
 /**
  * Extends ESLint's RuleTester to also build documentation


### PR DESCRIPTION
Some test runners validate the flags passed in (e.g. jest) so use environment variables which are less likely to conflict.

Deprecate the `--doc` flag and warn if it is used.

Fixes #78