### PR TITLE
Ensure config.docPath exists before writing output path.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1829,12 +1829,9 @@
 			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 		},
 		"mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-			"requires": {
-				"minimist": "^1.2.5"
-			}
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
 		},
 		"mocha": {
 			"version": "8.0.1",
@@ -2867,6 +2864,16 @@
 			"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
 			"requires": {
 				"mkdirp": "^0.5.1"
+			},
+			"dependencies": {
+				"mkdirp": {
+					"version": "0.5.5",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+					"requires": {
+						"minimist": "^1.2.5"
+					}
+				}
 			}
 		},
 		"write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"import-fresh": "^3.2.1",
 		"jsonschema": "^1.2.6",
 		"merge-options": "^2.0.0",
+		"mkdirp": "^1.0.4",
 		"pkg-dir": "^4.2.0",
 		"pluralize": "^8.0.0",
 		"simple-mock": "^0.8.0",

--- a/src/write-docs-from-tests.js
+++ b/src/write-docs-from-tests.js
@@ -2,6 +2,7 @@
 
 /* eslint-disable no-process-exit */
 const fs = require( 'fs' );
+const mkdirp = require( 'mkdirp' );
 const path = require( 'upath' );
 const buildDocsFromTests = require( './build-docs-from-tests' );
 
@@ -40,6 +41,7 @@ const { globalTemplates, loadRuleTemplate } = loadTemplates( templatePaths );
 function writeDocsFromTests( name, rule, tests, testerConfig, done ) {
 	const configMap = rulesWithConfig.get( name ).configMap;
 	const outputPath = packagePath( config.docPath.replace( '{name}', name ) );
+	const outputDir = packagePath( path.dirname( config.docPath ) );
 	let output, messages;
 	try {
 		( { output, messages } = buildDocsFromTests(
@@ -53,29 +55,31 @@ function writeDocsFromTests( name, rule, tests, testerConfig, done ) {
 		process.exit( 1 );
 	}
 
-	fs.writeFile(
-		outputPath,
-		output,
-		( err ) => {
-			if ( err ) {
-				messages.push( { type: 'error', text: err } );
-			}
-			if ( messages.length ) {
-				console.log();
-				console.log( formatter.heading( outputPath ) );
-				messages.forEach( ( message ) =>
-					console.log( formatter[ message.type ]( message.text, message.label ) )
-				);
-				console.log();
-			}
+	mkdirp( outputDir ).then( () => {
+		fs.writeFile(
+			outputPath,
+			output,
+			( err ) => {
+				if ( err ) {
+					messages.push( { type: 'error', text: err } );
+				}
+				if ( messages.length ) {
+					console.log();
+					console.log( formatter.heading( outputPath ) );
+					messages.forEach( ( message ) =>
+						console.log( formatter[ message.type ]( message.text, message.label ) )
+					);
+					console.log();
+				}
 
-			if ( messages.some( ( message ) => message.type === 'error' ) ) {
-				process.exit( 1 );
-			}
+				if ( messages.some( ( message ) => message.type === 'error' ) ) {
+					process.exit( 1 );
+				}
 
-			done();
-		}
-	);
+				done();
+			}
+		);
+	} );
 }
 
 module.exports = writeDocsFromTests;


### PR DESCRIPTION
Thanks for the great library!

When the `docPath` directory does not already exist, it throws an ENOENT error. This PR uses `mkdirp` to ensure the directory is created before writing the path.