### PR TITLE
Add support for per-rule config overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To migrate an existing plugin with manually built documentation you can use the 
 
 ## ⚙️ Configuration
 
-Create a JSON/JavaScript file called `.eslintdocgenrc.json`/`.eslintdocgenrc.js` in your project root:
+Configuration for all rules in a project is controlled by creating a JSON/JavaScript file called `.eslintdocgenrc.json`/`.eslintdocgenrc.js` in your project root:
 
 #### JSON
 ```jsonc
@@ -80,6 +80,10 @@ module.exports = {
     // ...
 };
 ```
+
+#### Overriding
+
+The project-wide rules configuration can be overridden for individual rules by adding a `docgenConfig` property to the tests object passed to RuleTester.run(). All configuration options that are supported project-wide can be changed.
 
 The following config options are available:
 

--- a/src/rule-tester.js
+++ b/src/rule-tester.js
@@ -23,7 +23,7 @@ class RuleTester extends ESLintRuleTester {
 				writeDocsFromTests( name, rule, tests, this.testerConfig, done );
 			} );
 		} else {
-			// Filter out invalid top level property "noDoc", used in documentation building mode
+			// Filter out invalid property "noDoc", used in documentation building mode
 			tests.valid.forEach( ( test ) => {
 				delete test.docgen;
 				// Deprecated
@@ -34,6 +34,10 @@ class RuleTester extends ESLintRuleTester {
 				// Deprecated
 				delete test.noDoc;
 			} );
+
+			// Filter out invalid top level property "docgenConfig", used in documentation building mode
+			delete tests.docgenConfig;
+
 			return super.run.call( this, name, rule, tests );
 		}
 	}


### PR DESCRIPTION
The tests object can now include a `docgenConfig` property that overrides the project-wide config
First part of addressing #98 