### PR TITLE
build-docs-from-tests: add Vue syntax highlighting

### DIFF
--- a/src/build-docs-from-tests.js
+++ b/src/build-docs-from-tests.js
@@ -218,7 +218,14 @@ function buildDocsFromTests(
 			const settings = optionsAndSettings && optionsAndSettings.settings;
 			const filename = optionsAndSettings && optionsAndSettings.filename;
 
-			let examples = '```js\n';
+			let syntaxHighlightLang = 'js';
+			// Switch to Vue if we are showing file names and its a Vue file.
+			// optionsAndSettings.filename is only set if it should be shown
+			// TODO should we add other languages too?
+			if ( filename && path.extname( filename ) === '.vue' ) {
+				syntaxHighlightLang = 'vue';
+			}
+			let examples = '```' + syntaxHighlightLang + '\n';
 			if ( config.showConfigComments ) {
 				examples += comments[ i ] + '\n';
 			}

--- a/tests/build-docs-from-tests.js
+++ b/tests/build-docs-from-tests.js
@@ -5,11 +5,28 @@ const fs = require( 'fs' );
 const path = require( 'upath' );
 const testUtils = require( './test-utils' );
 
+/**
+ * Returns the contents that would be appropriate for an overall
+ * .vue file, with the scriptContents being contained between <script></script>
+ * tags.
+ *
+ * @param {string} scriptContents
+ * @return {string}
+ */
+function makeVueFileContent( scriptContents ) {
+	const aboveScriptContents = `<template>
+	<p>Placeholder...</p>
+</template>
+<script>`;
+	return aboveScriptContents + '\n' + scriptContents + '\n</script>';
+}
+
 /* eslint-disable mocha/no-setup-in-describe */
 
 describe( 'buildDocsFromTests', () => {
 	const jsFilename = path.resolve( __dirname, '../sandbox/test.js' );
 	const tsFilename = path.resolve( __dirname, '../sandbox/test.ts' );
+	const vueFilename = path.resolve( __dirname, '../sandbox/test.vue' );
 
 	const noDesc = { type: 'warn', text: 'No description found in rule metadata' };
 	const cases = [
@@ -94,7 +111,7 @@ describe( 'buildDocsFromTests', () => {
 			name: 'file-rule',
 			ruleMeta: {
 				docs: {
-					description: 'File rule cares about the file name (variable names starting with "js" are reserved for JavaScript files, and "ts" are reserved for TypeScript files)'
+					description: 'File rule cares about the file name (variable names starting with "js" are reserved for JavaScript files, "ts" are reserved for TypeScript files, "vue" are reserved for scripts in Vue files). Code fixes are disabled.'
 				}
 			},
 			tests: {
@@ -102,43 +119,56 @@ describe( 'buildDocsFromTests', () => {
 					'var x = 123',
 					'var y = 456',
 					{
-						code: 'var jsX = 123',
+						code: 'var jsX = 123;',
 						filename: jsFilename
 					},
 					{
-						code: 'var jsY = 456',
+						code: 'var jsY = 456;',
 						filename: jsFilename
 					},
 					{
-						code: 'var tsX = 123',
+						code: 'var tsX = 123;',
 						filename: tsFilename
 					},
 					{
-						code: 'var tsY = 456',
+						code: 'var tsY = 456;',
 						filename: tsFilename
+					},
+					{
+						code: makeVueFileContent( 'var vueZ = 789;' ),
+						filename: vueFilename
 					}
 				],
 				invalid: [
 					{
-						code: 'var jsX = 123',
+						code: 'var jsX = 123;',
 						filename: tsFilename
 					},
 					{
-						code: 'var jsY = 456',
+						code: 'var jsY = 456;',
 						filename: tsFilename
 					},
 					{
-						code: 'var tsX = 123',
+						code: 'var tsX = 123;',
 						filename: jsFilename
 					},
 					{
-						code: 'var tsY = 456',
+						code: 'var tsY = 456;',
 						filename: jsFilename
+					},
+					{
+						code: makeVueFileContent( 'var jsZ = 789;' ),
+						filename: vueFilename
+					},
+					{
+						code: makeVueFileContent( 'var tsZ = 789;' ),
+						filename: vueFilename
 					}
 				]
 			},
 			config: {
-				showFilenames: true
+				showFilenames: true,
+				fixCodeExamples: false
 			},
 			expected: 'cases/file-rule.md'
 		},

--- a/tests/cases/file-rule.md
+++ b/tests/cases/file-rule.md
@@ -1,6 +1,6 @@
 # file-rule
 
-File rule cares about the file name (variable names starting with "js" are reserved for JavaScript files, and "ts" are reserved for TypeScript files)
+File rule cares about the file name (variable names starting with "js" are reserved for JavaScript files, "vue" are reserved for scripts in Vue files). Code fixes are disabled.
 
 ## Rule details
 
@@ -32,6 +32,35 @@ var jsY = 456;
 ```js
 var tsX = 123;
 var tsY = 456;
+```
+
+❌ Examples of **incorrect** code for a file named `test.vue`:
+```vue
+
+<template>
+    <p>Placeholder...</p>
+</template>
+<script>
+var jsZ = 789;
+</script>
+
+<template>
+    <p>Placeholder...</p>
+</template>
+<script>
+var tsZ = 789;
+</script>
+```
+
+✔️ Examples of **correct** code for a file named `test.vue`:
+```vue
+
+<template>
+    <p>Placeholder...</p>
+</template>
+<script>
+var vueZ = 789;
+</script>
 ```
 
 ## Resources


### PR DESCRIPTION
When showing file names, if a file name ends in '.vue' use Vue language highlighting for the examples markdown, instead of JavaScript. No support is added yet for any other language.
Update file-name test case to add vue examples. Requires disabling the fixCodeExamples config option for that test to have the intended Vue output in the docs.