### PR TITLE
Change the default icon for rules which are included in a preset

### DIFF
--- a/src/templates/inConfig.ejs
+++ b/src/templates/inConfig.ejs
@@ -1,1 +1,1 @@
-⚙️ This rule is enabled in `plugin:<%- pluginName %>/<%- inConfig.config %>`<%- include( 'optionsAndSettings', { data: inConfig } ) %>.
+📋 This rule is enabled in `plugin:<%- pluginName %>/<%- inConfig.config %>`<%- include( 'optionsAndSettings', { data: inConfig } ) %>.

--- a/tests/cases/simple-rule.md
+++ b/tests/cases/simple-rule.md
@@ -6,9 +6,9 @@ My rule enforces a thing
 
 ⚠️ This rule is deprecated. Use [`my-new-rule`](my-new-rule.md), [`my-other-rule`](my-other-rule.md) and [`third-rule`](third-rule.md) instead.
 
-⚙️ This rule is enabled in `plugin:my-plugin/recommended` with `[{"myOption":true}]` options.
+📋 This rule is enabled in `plugin:my-plugin/recommended` with `[{"myOption":true}]` options.
 
-⚙️ This rule is enabled in `plugin:my-plugin/strict`.
+📋 This rule is enabled in `plugin:my-plugin/strict`.
 
 🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 


### PR DESCRIPTION
A clipboard list is a better icon for presets, rather the gear
which indicates settings.
