### PR TITLE
lintFix: Check for custom parser in mergedConfig

### DIFF
--- a/src/fix.js
+++ b/src/fix.js
@@ -37,8 +37,8 @@ async function lintFix( code, testerConfig ) {
 
 	// TODO
 	// istanbul ignore next
-	if ( testerConfig && typeof testerConfig.parser === 'string' ) {
-		linter.defineParser( testerConfig.parser, require( testerConfig.parser ) );
+	if ( typeof mergedConfig.parser === 'string' ) {
+		linter.defineParser( mergedConfig.parser, require( mergedConfig.parser ) );
 	}
 
 	const result = linter.verifyAndFix( code, mergedConfig );


### PR DESCRIPTION
A custom parser could be defined in the repo's config,
as well as just in the test config.

Fixes #131
